### PR TITLE
Fix logging import redundancy in PnL module

### DIFF
--- a/src/treasury/pnl.py
+++ b/src/treasury/pnl.py
@@ -23,7 +23,6 @@ except ImportError:
         logger.info(f"⚡ {func_name}: {execution_time:.3f}s")
     def log_calculation_summary(module: str, deals_processed: int, errors: int, warnings: int):
         logger.info(f"{module}: {deals_processed} deals, {errors} erreurs")
-from .logging_config import logger, log_performance, log_calculation_summary
 
 
 def calculate_accrued_pnl(deal: GenericDeal, 


### PR DESCRIPTION
## Summary
- Remove duplicate logging import in `pnl.py` to rely on conditional import

## Testing
- `pytest tests/test_pnl.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab36a6d854832a8203f072fcc369c1